### PR TITLE
Add simple Flask adder example

### DIFF
--- a/fullstack_add/README.md
+++ b/fullstack_add/README.md
@@ -1,0 +1,18 @@
+# Fullstack Adder
+
+This example shows a minimal front-end and Python backend that add two numbers.
+
+## Backend
+
+The backend uses `Flask` to expose an API at `/add`. Install dependencies and run:
+
+```bash
+pip install flask flask-cors
+python3 backend/app.py
+```
+
+The server listens on port 5000.
+
+## Frontend
+
+Open `frontend/index.html` in a browser. Enter two numbers and click **Add** to send a request to the backend and display the result.

--- a/fullstack_add/backend/app.py
+++ b/fullstack_add/backend/app.py
@@ -1,0 +1,19 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+
+app = Flask(__name__)
+CORS(app)
+
+@app.route('/add', methods=['POST'])
+def add_numbers():
+    data = request.get_json()
+    a = data.get('a')
+    b = data.get('b')
+    try:
+        result = float(a) + float(b)
+    except (TypeError, ValueError):
+        return jsonify({'error': 'Invalid input'}), 400
+    return jsonify({'result': result})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/fullstack_add/frontend/index.html
+++ b/fullstack_add/frontend/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Adder</title>
+    <script>
+    async function sendAddRequest(event) {
+        event.preventDefault();
+        const a = document.getElementById('num1').value;
+        const b = document.getElementById('num2').value;
+        const response = await fetch('http://localhost:5000/add', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({a: a, b: b})
+        });
+        const data = await response.json();
+        if (response.ok) {
+            document.getElementById('result').textContent = 'Result: ' + data.result;
+        } else {
+            document.getElementById('result').textContent = data.error;
+        }
+    }
+    </script>
+</head>
+<body>
+    <h1>Adder</h1>
+    <form onsubmit="sendAddRequest(event)">
+        <input type="number" id="num1" required>
+        <input type="number" id="num2" required>
+        <button type="submit">Add</button>
+    </form>
+    <p id="result"></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Flask backend and HTML frontend that perform addition
- document how to run the example

## Testing
- `pip install flask flask-cors` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684022c82c8883259440d9513ac5a0fc